### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,9 +5,7 @@ class ItemsController < ApplicationController
   def index
     # idの降順で表示
     @items = Item.all.order(id: "DESC")
-    # ActiveHashのDeliveryFeeモデルの内容を、インスタンス@delivery_feeに代入
-    @delivery_fee = DeliveryFee.all
-    
+
     # Order機能の実装後コメントアウト解除
     # @orders = Order.all
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,10 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
+    # idの降順で表示
+    @items = Item.all.order(id: "DESC")
+    # ActiveHashのDeliveryFeeモデルの内容を、インスタンス@delivery_feeに代入
+    @delivery_fee = DeliveryFee.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,6 +7,9 @@ class ItemsController < ApplicationController
     @items = Item.all.order(id: "DESC")
     # ActiveHashのDeliveryFeeモデルの内容を、インスタンス@delivery_feeに代入
     @delivery_fee = DeliveryFee.all
+    
+    # Order機能の実装後コメントアウト解除
+    # @orders = Order.all
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -173,27 +173,6 @@
         </li>
       <% end %>
       <%# //Itemモデルに記録されている商品データをeachメソッドで並べる %>
-
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <%# <li class='list'> %>
-        <%# <%= link_to '#' do %>
-        <%# <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <%# <div class='item-info'> %>
-          <%# <h3 class='item-name'> %>
-            <%# 商品を出品してね！ %>
-          <%# </h3> %>
-          <%# <div class='item-price'> %>
-            <%# <span>99999999円<br>(税込み)</span> %>
-            <%# <div class='star-btn'> %>
-              <%# <%= image_tag "star.png", class:"star-icon" %>
-              <%# <span class='star-count'>0</span> %>
-            <%# </div> %>
-          <%# </div> %>
-        <%# </div> %>
-        <%# <% end %>
-      <%# </li> %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -155,27 +155,27 @@
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
+      <%# <li class='list'> %>
+        <%# <%= link_to '#' do %>
+        <%# <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+        <%# <div class='item-info'> %>
+          <%# <h3 class='item-name'> %>
+            <%# 商品を出品してね！ %>
+          <%# </h3> %>
+          <%# <div class='item-price'> %>
+            <%# <span>99999999円<br>(税込み)</span> %>
+            <%# <div class='star-btn'> %>
+              <%# <%= image_tag "star.png", class:"star-icon" %>
+              <%# <span class='star-count'>0</span> %>
+            <%# </div> %>
+          <%# </div> %>
+        <%# </div> %>
+        <%# <% end %>
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,36 +126,48 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <%# Itemモデルに記録されている商品データをeachメソッドで並べる %>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to "#" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+              <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れていればsold outを表示しましょう %>
+              
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span>
+                  <%= item.price %>円<br>
 
-      
+                  <%# ActiveHashのDeliveryFeeモデルのidと、Itemモデルに記録されたdelivery_fee_idが一致した:nameを表示する %>
+                  <% @delivery_fee.each do |fee| %>
+                    <% if fee.id == item.delivery_fee_id %>
+                      <%= fee.name %>
+                    <% end %>
+                  <% end %>
+                  <%# //ActiveHashのDeliveryFeeモデルのidと、Itemモデルに記録されたdelivery_fee_idが一致した:nameを表示する %>
+
+                </span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
+      <%# //Itemモデルに記録されている商品データをeachメソッドで並べる %>
+
       <%# 商品がある場合は表示されないようにしましょう %>
       <%# <li class='list'> %>
         <%# <%= link_to '#' do %>
@@ -173,7 +185,7 @@
           <%# </div> %>
         <%# </div> %>
         <%# <% end %>
-      </li>
+      <%# </li> %>
       <%# //商品がある場合は表示されないようにしましょう %>
       
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,37 +126,62 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# Itemモデルに記録されている商品データをeachメソッドで並べる %>
-      <% @items.each do |item| %>
-        <li class='list'>
-          <%= link_to "#" do %>
-            <div class='item-img-content'>
-              <%= image_tag item.image, class: "item-img" %>
+      <%# 条件分岐:@itemに商品データが存在するならtrue %>
+      <% if @items.present? %>
+        <%# Itemモデルに記録されている商品データをeachメソッドで並べる %>
+        <% @items.each do |item| %>
+        
+          <li class='list'>
+            <%= link_to "#" do %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: "item-img" %>
 
-              <%# Order機能の実装後コメントアウト解除 %>
-              <%# 売れた商品のid(Orderモデルのitem_id)とItemモデルのidが一致した場合、Sold Outを表示 %>
-              <%# <% @orders.each do |order| %>
-                <%# <% if order.item_id == item.id %>
-                  <%# <div class='sold-out'> %>
-                  <%# <span>Sold Out!!</span> %>
-                  <%# </div> %>
+                <%# Order機能の実装後コメントアウト解除 %>
+                <%# 売れた商品のid(Orderモデルのitem_id)とItemモデルのidが一致した場合、Sold Outを表示 %>
+                <%# <% @orders.each do |order| %>
+                  <%# <% if order.item_id == item.id %>
+                    <%# <div class='sold-out'> %>
+                    <%# <span>Sold Out!!</span> %>
+                    <%# </div> %>
+                  <%# <% end %>
                 <%# <% end %>
-              <%# <% end %>
-              <%# //売れた商品のid(Orderモデルのitem_id)とItemモデルのidが一致した場合、Sold Outを表示 %>
-              <%# //Order機能の実装後コメントアウト解除 %>
+                <%# //売れた商品のid(Orderモデルのitem_id)とItemモデルのidが一致した場合、Sold Outを表示 %>
+                <%# //Order機能の実装後コメントアウト解除 %>
 
-            </div>
+              </div>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.name %>
+                </h3>
+                <div class='item-price'>
+                  <span>
+                    <%= item.price %>円<br>
+                    <%# アソシエーションを組んだActive_hash DeliveryFeeモデルから:nameを取り出す %>
+                    <%= item.Delivery_fee.name %>
+                    <%# //アソシエーションを組んだActive_hash DeliveryFeeモデルから:nameを取り出す %>
+                  </span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </li>
+        <% end %>
+        <%# //Itemモデルに記録されている商品データをeachメソッドで並べる %>
+
+      <%# @itemに商品データがない場合はダミー商品を表示する %>
+      <% else %>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
             <div class='item-info'>
               <h3 class='item-name'>
-                <%= item.name %>
+                商品を出品してね！
               </h3>
               <div class='item-price'>
-                <span>
-                  <%= item.price %>円<br>
-                  <%# アソシエーションを組んだActive_hash DeliveryFeeモデルから:nameを取り出す %>
-                  <%= item.Delivery_fee.name %>
-                  <%# //アソシエーションを組んだActive_hash DeliveryFeeモデルから:nameを取り出す %>
-                </span>
+                <span>99999999円<br>(税込み)</span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class='star-count'>0</span>
@@ -166,30 +191,8 @@
           <% end %>
         </li>
       <% end %>
-
-      <%# 商品がある場合は表示されないダミー商品 %>
-      <%# Itemモデルにデータが存在するかの条件分岐 %>
-      <% if Item.nil? %>
-      <li class='list'>
-        <%= link_to '#' do %>
-         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-          <div class='item-info'>
-            <h3 class='item-name'>
-              商品を出品してね！
-            </h3>
-            <div class='item-price'>
-             <span>99999999円<br>(税込み)</span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
-              </div>
-            </div>
-          </div>
-        <% end %>
-      </li>
-      <% end %>
-      <%# //Itemモデルにデータが存在するかの条件分岐 %>
-      <%# //商品がある場合は表示されないダミー商品 %>
+      <%# //@itemに商品データがない場合はダミー商品を表示する %>
+      <%# //条件分岐:@itemに商品データが存在するならtrue %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -153,15 +153,9 @@
               <div class='item-price'>
                 <span>
                   <%= item.price %>円<br>
-
-                  <%# ActiveHashのDeliveryFeeモデルのidと、Itemモデルに記録されたdelivery_fee_idが一致した:nameを表示する %>
-                  <% @delivery_fee.each do |fee| %>
-                    <% if fee.id == item.delivery_fee_id %>
-                      <%= fee.name %>
-                    <% end %>
-                  <% end %>
-                  <%# //ActiveHashのDeliveryFeeモデルのidと、Itemモデルに記録されたdelivery_fee_idが一致した:nameを表示する %>
-
+                  <%# アソシエーションを組んだActive_hash DeliveryFeeモデルから:nameを取り出す %>
+                  <%= item.Delivery_fee.name %>
+                  <%# //アソシエーションを組んだActive_hash DeliveryFeeモデルから:nameを取り出す %>
                 </span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -166,7 +166,30 @@
           <% end %>
         </li>
       <% end %>
-      <%# //Itemモデルに記録されている商品データをeachメソッドで並べる %>
+
+      <%# 商品がある場合は表示されないダミー商品 %>
+      <%# Itemモデルにデータが存在するかの条件分岐 %>
+      <% if Item.nil? %>
+      <li class='list'>
+        <%= link_to '#' do %>
+         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+             <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </li>
+      <% end %>
+      <%# //Itemモデルにデータが存在するかの条件分岐 %>
+      <%# //商品がある場合は表示されないダミー商品 %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,12 +133,18 @@
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
 
-              <%# 商品が売れていればsold outを表示しましょう %>
-              <div class='sold-out'>
-              <span>Sold Out!!</span>
-              </div>
-              <%# //商品が売れていればsold outを表示しましょう %>
-              
+              <%# Order機能の実装後コメントアウト解除 %>
+              <%# 売れた商品のid(Orderモデルのitem_id)とItemモデルのidが一致した場合、Sold Outを表示 %>
+              <%# <% @orders.each do |order| %>
+                <%# <% if order.item_id == item.id %>
+                  <%# <div class='sold-out'> %>
+                  <%# <span>Sold Out!!</span> %>
+                  <%# </div> %>
+                <%# <% end %>
+              <%# <% end %>
+              <%# //売れた商品のid(Orderモデルのitem_id)とItemモデルのidが一致した場合、Sold Outを表示 %>
+              <%# //Order機能の実装後コメントアウト解除 %>
+
             </div>
             <div class='item-info'>
               <h3 class='item-name'>


### PR DESCRIPTION
# What
### 商品一覧表示機能
#### 実装の条件
- 画像が表示されており、画像がリンク切れなどになっていないこと（Herokuの仕様による画像のリンク切れは、要件未達に含まれない。デプロイのタスクにあるとおり、Heroku上では一定時間経過すると画像が消える。）
- 出品した商品の一覧表示ができている。かつ「画像/価格/商品名」の3つの情報について表示できていること
- 売却済みの商品は、「sold out」の文字が表示されるようになっていること(コメントアウト状態）
- ログアウトした状態でも商品一覧ページを見ることができること

# Why
#### 新規登録の商品がトップに更新され、簡易的な商品情報や、売れた物を提示する事で購買意欲を刺激する

# 実装機能の確認動画/画像
#### ・出品した商品の一覧表示が出来、かつ「画像/価格/商品名」の3つの情報について表示できている
データベースの画像
◆https://gyazo.com/123efc7e0ef829579b524979ad4f1fee
商品一覧の画像
◆https://gyazo.com/099b6668a3af4a6b9aa0b8852dcbc298
#### ・ログインした状態で商品一覧を見ることができる
□https://gyazo.com/6490ac31eee97e67ae14385c47c0ded3
#### ・ログアウトした状態でも商品一覧を見ることができる
□https://gyazo.com/65a223c53c82b93ad559f1767716d6b9
#### ・新規に出品した商品が最新の商品の場所に表示される
□https://gyazo.com/d0db8fcaa3f9b6478d271bf65fb2d9d1
