### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,7 +26,7 @@ class ItemsController < ApplicationController
       @item.save
       redirect_to action: :index
     else
-      render action: :new
+      redirect_to new_item_path, flash: { error: @item.errors.full_messages }
     end
   end
 
@@ -40,7 +40,7 @@ class ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to action: :index
     else
-      render action: :edit
+      redirect_to edit_item_path, flash: { error: @item.errors.full_messages }
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,10 +3,10 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   # ＠itemに特定のIDのパラメーターを代入するメソッド（同じ記述を減らすために定義）
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   # 商品のuser.idと出品者のidが一致しない場合indexページへ遷移するメソッド
-  before_action :move_to_index, only: [:edit, :update]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
 
   def index
     # idの降順で表示
@@ -43,6 +43,12 @@ class ItemsController < ApplicationController
       render action: :edit
     end
   end
+
+  def destroy
+    @item.destroy
+    redirect_to action: :index
+  end
+
 
   private
   def item_params 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -37,7 +37,7 @@
 
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path, method: :delete, class:"item-destroy" %>
 
       <%# Order機能実装後、46行目のelsifの条件文に置換 %>
       <% else %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,9 +1,9 @@
-<% if model.errors.any? %>
-<div class="error-alert">
-  <ul>
-    <% model.errors.full_messages.each do |message| %>
-    <li class='error-message'><%= message %></li>
-    <% end %>
-  </ul>
-</div>
+<% if flash[:error].present? %>
+  <div class="error-alert">
+    <ul>
+      <% flash[:error].each do |message| %>
+        <li class='error-message'><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
 <% end %>

--- a/app/views/shared/_form.html.erb
+++ b/app/views/shared/_form.html.erb
@@ -3,9 +3,11 @@
   <%= form_with model: @item, local: true do |f| %>
 
     <%# エラーメッセージ表示の部分テンプレート %>
-    <%= render "shared/error_messages", model: f.object %>
+    <%= render "shared/error_messages" %>
     <%# /エラーメッセージ表示の部分テンプレート %>
   
+    
+
     <%# 出品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
### 商品情報編集機能の実装
#### 商品削除機能の実装
- 出品者だけが商品情報を削除できること
# Why
#### 間違って出品してしまった商品をすぐに削除できる様にするため

# 実装機能の確認動画/画像
#### ・削除ボタンをクリックすると出品した商品を削除できる
商品削除前のデータベース
◆https://gyazo.com/50020f272baab305b13489f417f3d004
商品削除の操作
□https://gyazo.com/7882bcd8f406db2dd28b883ec834819f
商品削除後のデータベース
◆https://gyazo.com/2ed64e83007771861059db6666360074

